### PR TITLE
Add keywords.txt

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -5,3 +5,8 @@
           descr: Initial version of the library
         - year: 2018
           descr: Initial version of the C++ Wrapper
+- name: per1234
+  email:
+  contributions:
+        - year: 2018
+          descr: Add keywords.txt

--- a/sha/keywords.txt
+++ b/sha/keywords.txt
@@ -1,0 +1,7 @@
+Sha256	KEYWORD1		DATA_TYPE
+
+init	KEYWORD2
+result	KEYWORD2
+initHmac	KEYWORD2
+resultHmac	KEYWORD2
+write	KEYWORD2


### PR DESCRIPTION
This file will cause the functions and objects of the library to be highlighted in the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

I added an entry to contributors.yml as instructed in the readme but am happy to remove that part of the change if that was not the correct thing to do.

Resolves https://github.com/daknuett/cryptosuite2/issues/3