### PR TITLE
Fix digest example value and print out length

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,3 +16,8 @@
           descr: Add library.properties
         - year: 2019
           descr: Move example sketches to appropriately named folders
+- name: JoshHeaney
+  email:
+  contributions:
+        - year: 2019
+          descr: SHA256 and SHA1 HMAC example digest fix.

--- a/sha/examples/sha1/sha1.ino
+++ b/sha/examples/sha1/sha1.ino
@@ -22,7 +22,7 @@ void loop(void)
 
         Serial.print("Hash:\n");
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 20; i++) {
                 Serial.print("0123456789abcdef"[result[i] >> 4]);
                 Serial.print("0123456789abcdef"[result[i] & 0xf]);
         }

--- a/sha/examples/sha1HMAC/sha1HMAC.ino
+++ b/sha/examples/sha1HMAC/sha1HMAC.ino
@@ -10,9 +10,9 @@ void setup(void)
         Sha1.print("what do ya want for nothing?");
         uint8_t * result = Sha1.resultHmac();
 
-        Serial.println("Expect: b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+        Serial.println("Expect: effcdf6ae5eb2fa2d27416d5f184df9c259a7c79");
         Serial.print(  "Got   : ");
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 20; i++) {
                 Serial.print("0123456789abcdef"[result[i] >> 4]);
                 Serial.print("0123456789abcdef"[result[i] & 0xf]);
         }

--- a/sha/examples/sha256HMAC/sha256HMAC.ino
+++ b/sha/examples/sha256HMAC/sha256HMAC.ino
@@ -10,7 +10,7 @@ void setup(void)
         Sha256.print("what do ya want for nothing?");
         uint8_t * result = Sha256.resultHmac();
 
-        Serial.println("Expect: b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+        Serial.println("Expect: 5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843");
         Serial.print(  "Got   : ");
         for (int i = 0; i < 32; i++) {
                 Serial.print("0123456789abcdef"[result[i] >> 4]);


### PR DESCRIPTION
Thanks for working on this library! I noticed a couple issues while running the examples, feel free to verify my work.

SHA1 standard digest length is 40 digits in hex. The for loop in the sha1 examples should use 20 vice 10.

The expected sha1HMAC for the given example should be: 
`effcdf6ae5eb2fa2d27416d5f184df9c259a7c79`

The expected sha1HMAC for the given example should be: `5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843`
(This one is in the [RFC](https://tools.ietf.org/html/rfc4231) Section 4.3)