### PR TITLE
Remove the test sketches from the regular build on PlatformIO.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -30,3 +30,10 @@
           descr: fix expected hmac256 test output
         - year: 2020
           descr: Moved some data from RAM to flash in the examples
+- name: Christoph Honal
+  email: 
+  contributions:
+        - year: 2021
+          descr: Remove test sketches from the regular build on PlatformIO
+        - year: 2021
+          descr: Fix out-of-bounds memory access in SHA1 hashing

--- a/library.json
+++ b/library.json
@@ -10,5 +10,9 @@
 	},
 	"version": "0.2.5",
 	"platforms": "*",
-	"examples":["sha/examples/*/*.ino"]
+	"examples": [ "sha/examples/*/*.ino" ],
+	"build":
+	{
+		"srcFilter": "+<*> -<.git/> -<sha/examples/> -<sha/test/> -<tools/> -<doc/> -<docs/>"
+	}
 }


### PR DESCRIPTION
This fixes issue #16 , by specifying a `srcFilter` directive in the `build` definition of the PlatformIO `library.json` file. This filter excludes any examples and tests when the library is built.

This change is required because otherwise the test code files would end up in the archived library, clashing with the main program:
```
Compiling .pio/build/uno/lib6d7/cryptosuite2/sha/test/test_sha1.c.o
Compiling .pio/build/uno/lib6d7/cryptosuite2/sha/test/test_sha256.c.o
```