### PR TITLE
Fix loop overflow in SHA1 gethash

### DIFF
--- a/sha/sha1/hash.c
+++ b/sha/sha1/hash.c
@@ -159,7 +159,7 @@ uint8_t * sha1_hasher_gethash(sha1_hasher_t hasher)
 	int i;
 
 	// switch byte order.
-	for(i = 0; i < 8; i++)
+	for(i = 0; i < (SHA1_HASH_LEN / 4); i++)
 	{
 		uint32_t a, b;
 		a = hasher->state.words[i];


### PR DESCRIPTION
This fixes a small out-of-bounds array access in `sha1_hasher_gethash`, where the loop assumed to always iterate over `8` elements instead of `SHA1_HASH_LEN / 4` (which is `5`). This would lead to compiler warnings like this:

```
In file included from lib/cryptosuite2/sha/backend.cpp:28:0:
lib/cryptosuite2/sha/sha1/sha1.c: In function 'sha1_hasher_gethash(sha1_hasher_s*)':
lib/cryptosuite2/sha/sha1/hash.c:165:5: warning: iteration 5 invokes undefined behavior [-Waggressive-loop-optimizations]
   a = hasher->state.words[i];
   ~~^~~~~~~~~~~~~~~~~~~~~~~~
lib/cryptosuite2/sha/sha1/hash.c:162:15: note: within this loop
  for(i = 0; i < 8; i++)
             ~~^~~
lib/cryptosuite2/sha/sha1/hash.c: In function 'sha1_hasher_gethash':
lib/cryptosuite2/sha/sha1/hash.c:165:5: warning: iteration 5 invokes undefined behavior [-Waggressive-loop-optimizations]
   a = hasher->state.words[i];
   ~~^~~~~~~~~~~~~~~~~~~~~~~~
lib/cryptosuite2/sha/sha1/hash.c:162:2: note: within this loop
  for(i = 0; i < 8; i++)
  ^~~
```

I tested the SHA1 hashing using the provided test programs, it still works just fine. Although this problem is not critical for the SHA1 functionality, it's not good to flip bytes in some random memory regions.
