### PR TITLE
Add leading zeros to print functions in tests

### DIFF
--- a/sha/test/test_sha1.c
+++ b/sha/test/test_sha1.c
@@ -24,7 +24,7 @@ void print_hash(uint8_t * result)
 	int i;
 	for(i = 0; i < SHA1_HASH_LEN; i++)
 	{
-		printf("%2x", result[i]);
+		printf("%02x", result[i]);
 	}
 	printf("\n");
 }

--- a/sha/test/test_sha256.c
+++ b/sha/test/test_sha256.c
@@ -24,7 +24,7 @@ void print_hash(uint8_t * result)
 	int i;
 	for(i = 0; i < SHA256_HASH_LEN; i++)
 	{
-		printf("%2x", result[i]);
+		printf("%02x", result[i]);
 	}
 	printf("\n");
 }


### PR DESCRIPTION
This small change just improves the printing of the hash results in the test functions.

Previously, zeros would be printed as an empty space, now they are printed properly as zeros. This makes it easier to compare the output by eye.