### PR TITLE
Bump platformio version to 0.2.6

### DIFF
--- a/library.json
+++ b/library.json
@@ -8,7 +8,7 @@
 		"branch": "master",
 		"url": "https://github.com/daknuett/cryptosuite2.git"
 	},
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"platforms": "*",
 	"examples": [ "sha/examples/*/*.ino" ],
 	"build":


### PR DESCRIPTION
This PR bumps the PlatfomIO package version the the most recent release version (v0.2.6). This should trigger the update of the hosted package at https://platformio.org/lib/show/5829/cryptosuite2 .